### PR TITLE
wechat-uos: fix ldconfig crash on latest buildFHSEnv

### DIFF
--- a/pkgs/uncategorized/wechat-uos/default.nix
+++ b/pkgs/uncategorized/wechat-uos/default.nix
@@ -179,6 +179,8 @@ let
       "--chdir $HOME"
       "--setenv QT_QPA_PLATFORM xcb"
       "--setenv QT_AUTO_SCREEN_SCALE_FACTOR 1"
+    ] ++ [
+      "--tmpfs ${glibcWithoutHardening}/etc"
     ];
 
     unshareUser = true;


### PR DESCRIPTION
With latest nixpkgs, wechat-uos failed to run with
```
/bin/ldconfig: Can't create temporary cache file /nix/store/yi02j2ivpwcrv3s9wwsbi6qxfj03gphd-glibc-2.40-36/etc/ld.so.cache~: Read-only file system
ldconfig exited 1
```
This may be caused by https://github.com/NixOS/nixpkgs/commit/70cb669a2f5608583caedde7e691b104f83ad718 . I'm not sure whether the solution in this pr is optimal, but it works anyway.