### PR TITLE
dingtalk: remove xorg prefix as nixpkgs package hierarchy changed

### DIFF
--- a/pkgs/uncategorized/dingtalk/default.nix
+++ b/pkgs/uncategorized/dingtalk/default.nix
@@ -61,7 +61,27 @@
   rtmpdump,
   udev,
   util-linux,
-  xorg,
+  libICE,
+  libSM,
+  libX11,
+  libxcb,
+  libXcomposite,
+  libXcursor,
+  libXdamage,
+  libXext,
+  libXfixes,
+  libXi,
+  libXinerama,
+  libXmu,
+  libXrandr,
+  libXrender,
+  libXScrnSaver,
+  libXt,
+  libXtst,
+  xcbutilimage,
+  xcbutilkeysyms,
+  xcbutilrenderutil,
+  xcbutilwm,
 }:
 ################################################################################
 # Mostly based on dingtalk-bin package from AUR:
@@ -125,27 +145,27 @@ let
     rtmpdump
     udev
     util-linux
-    xorg.libICE
-    xorg.libSM
-    xorg.libX11
-    xorg.libxcb
-    xorg.libXcomposite
-    xorg.libXcursor
-    xorg.libXdamage
-    xorg.libXext
-    xorg.libXfixes
-    xorg.libXi
-    xorg.libXinerama
-    xorg.libXmu
-    xorg.libXrandr
-    xorg.libXrender
-    xorg.libXScrnSaver
-    xorg.libXt
-    xorg.libXtst
-    xorg.xcbutilimage
-    xorg.xcbutilkeysyms
-    xorg.xcbutilrenderutil
-    xorg.xcbutilwm
+    libICE
+    libSM
+    libX11
+    libxcb
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXinerama
+    libXmu
+    libXrandr
+    libXrender
+    libXScrnSaver
+    libXt
+    libXtst
+    xcbutilimage
+    xcbutilkeysyms
+    xcbutilrenderutil
+    xcbutilwm
   ];
 in
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/uncategorized/dingtalk/wayland-screenshare.nix
+++ b/pkgs/uncategorized/dingtalk/wayland-screenshare.nix
@@ -9,7 +9,13 @@
   libportal,
   pipewire,
   opencv,
-  xorg,
+  libX11,
+  libXcomposite,
+  libXdamage,
+  libXext,
+  libXfixes,
+  libXrandr,
+  libXtst,
 }:
 # https://github.com/xddxdd/nur-packages/issues/71
 stdenv.mkDerivation {
@@ -28,13 +34,13 @@ stdenv.mkDerivation {
     pipewire
     opencv
     # X11 依赖 (Hook 需要操作 X11 窗口)
-    xorg.libX11
-    xorg.libXcomposite
-    xorg.libXdamage
-    xorg.libXext
-    xorg.libXfixes
-    xorg.libXrandr
-    xorg.libXtst
+    libX11
+    libXcomposite
+    libXdamage
+    libXext
+    libXfixes
+    libXrandr
+    libXtst
   ];
   # 修复构建错误：这是库文件，不需要 wrap
   dontWrapQtApps = true;


### PR DESCRIPTION
See also: https://github.com/NixOS/nixpkgs/issues/479553

I just fix deprecated warning in dingtalk since I use it. Feel free to modify any code on my PR to suit your code style & conduction, or close it if you want to refactor this whole repo by your self.